### PR TITLE
auto fix common JSON syntax errors

### DIFF
--- a/lib/commands/base.coffee
+++ b/lib/commands/base.coffee
@@ -31,6 +31,11 @@ class BaseCommand
     return unless editor?
 
     text = editor.getSelectedText() or editor.getText()
+    try
+      text = JSON.stringify(JSON.parse(text), null, 4)
+    catch error
+      if !(error instanceof SyntaxError)
+        throw error
 
   showResult: (error, response) ->
     if error


### PR DESCRIPTION
-  fixes common errors during development
-  allows for ommiting quotes `"`

this will now pass

``` javascript
{
  query: {
    "bool": {
      must: [{
        match_all: {}
      }, ]
    },
  },
}
```
